### PR TITLE
fix: add ADMIN_TOKEN to docker-compose environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       - INITIAL_SEARCH_LIMIT=${INITIAL_SEARCH_LIMIT:-15}
       - KEYWORD_BOOST_FACTOR=${KEYWORD_BOOST_FACTOR:-0.05}
       - EMBEDDING_TIMEOUT=${EMBEDDING_TIMEOUT:-30.0}
+      
+      # Admin configuration
+      - ADMIN_TOKEN=${ADMIN_TOKEN}
     # Add extra_hosts for connecting to host machine services like Ollama
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
- Pass ADMIN_TOKEN environment variable to the memory-api container
- Required for admin endpoints to authenticate properly

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>